### PR TITLE
🐛 Fixed the ram detection bug

### DIFF
--- a/src/main/java/de/gnmyt/mcdash/api/controller/StatsController.java
+++ b/src/main/java/de/gnmyt/mcdash/api/controller/StatsController.java
@@ -12,7 +12,7 @@ public class StatsController {
     private final File SERVER_FOLDER = new File(".");
     private final TPSRunnable TPS_RUNNABLE = new TPSRunnable();
 
-    private MinecraftDashboard instance;
+    private final MinecraftDashboard instance;
 
     /**
      * Basic constructor of the {@link StatsController}
@@ -52,7 +52,7 @@ public class StatsController {
      * @return the maximum amount of memory that the jvm will use
      */
     public long getTotalMemory() {
-        return Runtime.getRuntime().totalMemory();
+        return Runtime.getRuntime().maxMemory();
     }
 
     /**


### PR DESCRIPTION
# 🐛 Fixed the ram detection bug

The `StatsController` used to show the `totalMemory` instead of the `maxMemory`. This closes #11