### PR TITLE
🧩 Updated the plugins page

### DIFF
--- a/src/main/java/de/gnmyt/mcdash/panel/routes/plugin/PluginListRoute.java
+++ b/src/main/java/de/gnmyt/mcdash/panel/routes/plugin/PluginListRoute.java
@@ -8,6 +8,8 @@ import de.gnmyt.mcdash.api.json.ArrayBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
+import java.io.File;
+
 public class PluginListRoute extends DefaultHandler {
 
     @Override
@@ -26,11 +28,17 @@ public class PluginListRoute extends DefaultHandler {
         ArrayBuilder builder = new ArrayBuilder();
 
         for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
+            if (plugin.getClass().getProtectionDomain().getCodeSource() == null) continue;
+            String pluginJar = plugin.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
+            String pluginJarNoPath = pluginJar.substring(pluginJar.lastIndexOf(File.separator) + 1);
+            
+            if (!new File("./plugins/" + pluginJarNoPath).exists()) continue;
+
             builder.addNode()
                     .add("name", plugin.getName())
                     .add("author", plugin.getDescription().getAuthors().size() == 0 ? null : plugin.getDescription().getAuthors().get(0))
                     .add("description", plugin.getDescription().getDescription())
-                    .add("path", plugin.getClass().getProtectionDomain().getCodeSource().getLocation().getFile())
+                    .add("path", pluginJarNoPath)
                     .add("enabled", plugin.isEnabled())
                     .add("version", plugin.getDescription().getVersion())
                     .register();

--- a/src/main/java/de/gnmyt/mcdash/panel/routes/store/StoreRoute.java
+++ b/src/main/java/de/gnmyt/mcdash/panel/routes/store/StoreRoute.java
@@ -71,8 +71,7 @@ public class StoreRoute extends DefaultHandler {
         if (!isStringInQuery(request, response, "id")) return;
 
         HttpUrl url = HttpUrl.parse(ROOT_URL + "resources/" + URLEncoder.encode(request.getQuery()
-                        .get("id"), UTF_8.toString())).newBuilder().addQueryParameter("game_versions",
-                "[\"" + Bukkit.getServer().getBukkitVersion().split("-")[0] + "\"]").build();
+                .get("id"), UTF_8.toString())).newBuilder().build();
 
         okhttp3.Response httpResponse = client.newCall(new okhttp3.Request.Builder().url(url).build()).execute();
 
@@ -89,7 +88,7 @@ public class StoreRoute extends DefaultHandler {
             return;
         }
 
-        String fileUrl = ROOT_URL + "resources/"+ URLEncoder.encode(request.getQuery().get("id"), UTF_8.toString())
+        String fileUrl = ROOT_URL + "resources/" + URLEncoder.encode(request.getQuery().get("id"), UTF_8.toString())
                 + "/download";
 
         if (new File("plugins//Managed-" + projectId + ".jar").exists()) {
@@ -103,9 +102,10 @@ public class StoreRoute extends DefaultHandler {
         runSync(() -> {
             try {
                 Bukkit.getPluginManager().loadPlugin(new File("plugins//Managed-" + projectId + ".jar"));
-            } catch (InvalidPluginException | InvalidDescriptionException e) {
+            } catch (Exception e) {
                 FileUtils.deleteQuietly(new File("plugins//Managed-" + projectId + ".jar"));
-                response.code(400).message("The item with the id '" + projectId + "' is not a valid plugin");
+                response.code(400).json("message=\"The item with the id '" + projectId
+                                + "' is not a valid plugin\"", "error=\"" + e.getMessage() + "\"");
                 return;
             }
             response.message("The item with the id '" + projectId + "' has been installed");

--- a/src/main/java/de/gnmyt/mcdash/panel/routes/store/StoreRoute.java
+++ b/src/main/java/de/gnmyt/mcdash/panel/routes/store/StoreRoute.java
@@ -40,6 +40,7 @@ public class StoreRoute extends DefaultHandler {
         HttpUrl url = HttpUrl.parse(ROOT_URL + base).newBuilder()
                 .addQueryParameter("size", "35")
                 .addQueryParameter("page", String.valueOf(page))
+                .addQueryParameter("sort", "-downloads")
                 .build();
 
         okhttp3.Response httpResponse = client.newCall(new okhttp3.Request.Builder().url(url).build()).execute();

--- a/webui/src/common/components/ActionConfirmDialog/ActionConfirmDialog.jsx
+++ b/webui/src/common/components/ActionConfirmDialog/ActionConfirmDialog.jsx
@@ -25,13 +25,14 @@ export const ActionConfirmDialog = ({open, setOpen, title, description, buttonTe
 
     return (
         <>
-            <Snackbar open={snackbarOpen} autoHideDuration={3000} onClose={() => setSnackbarOpen(false)}
-                      anchorOrigin={{vertical: "bottom", horizontal: "right"}}>
-                <Alert onClose={() => setSnackbarOpen(false)} severity={actionFailed ? "error" : "success"}
-                       sx={{width: '100%'}}>
-                    {actionFailed ? "Could not execute action" : (successMessage || "Action executed successfully")}
-                </Alert>
-            </Snackbar>
+            {successMessage !== "none" &&
+                <Snackbar open={snackbarOpen} autoHideDuration={3000} onClose={() => setSnackbarOpen(false)}
+                          anchorOrigin={{vertical: "bottom", horizontal: "right"}}>
+                    <Alert onClose={() => setSnackbarOpen(false)} severity={actionFailed ? "error" : "success"}
+                           sx={{width: '100%'}}>
+                        {actionFailed ? "Could not execute action" : (successMessage || "Action executed successfully")}
+                    </Alert>
+                </Snackbar>}
             <Dialog open={open} onClose={() => setOpen(false)} aria-labelledby="alert-dialog-title"
                     aria-describedby="alert-dialog-description">
                 <DialogTitle id="alert-dialog-title">

--- a/webui/src/states/Root/pages/Plugins/Plugins.jsx
+++ b/webui/src/states/Root/pages/Plugins/Plugins.jsx
@@ -1,4 +1,4 @@
-import {Box, Button, Stack, TextField, Typography} from "@mui/material";
+import {Box, Button, Chip, Stack, TextField, Typography} from "@mui/material";
 import React, {useContext, useState} from "react";
 import {PluginsContext} from "@/states/Root/pages/Plugins/contexts/Plugins";
 import {PluginItem} from "@/states/Root/pages/Plugins/components/PluginItem/PluginItem.jsx";
@@ -15,7 +15,8 @@ export const Plugins = () => {
     return (
         <>
             <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between", mt: 2, mb: 2}}>
-                <Typography variant="h5" fontWeight={500}>Plugins</Typography>
+                <Typography variant="h5" fontWeight={500}>Plugins <Chip label={plugins.length}
+                                                                        color="secondary"/></Typography>
 
                 <Stack direction="row" spacing={1}>
                     {storeOpen && <TextField label="Search" variant="outlined" size={"small"} sx={{width: {xs: 150, lg: 300}}}
@@ -28,7 +29,7 @@ export const Plugins = () => {
             </Box>
 
             {!storeOpen && <Stack direction="row" sx={{my: 1, alignItems: "baseline"}} flexWrap="wrap">
-                {plugins.map((plugin) => <PluginItem key={plugin.name} {...plugin} />)}
+                {plugins.map((plugin) => <PluginItem key={plugin.path} {...plugin} />)}
             </Stack>}
 
             {storeOpen && <PluginStore search={currentSearch} closeStore={() => setStoreOpen(false)} />}

--- a/webui/src/states/Root/pages/Plugins/components/PluginItem/PluginItem.jsx
+++ b/webui/src/states/Root/pages/Plugins/components/PluginItem/PluginItem.jsx
@@ -1,15 +1,28 @@
-import {Box, Button, Chip, Stack, Typography} from "@mui/material";
-import React, {useContext} from "react";
+import {Box, Button, Chip, IconButton, Stack, Typography} from "@mui/material";
+import React, {useContext, useState} from "react";
 import {deleteRequest, postRequest} from "@/common/utils/RequestUtil.js";
 import {PluginsContext} from "@/states/Root/pages/Plugins/contexts/Plugins";
+import {Delete} from "@mui/icons-material";
+import ActionConfirmDialog from "@components/ActionConfirmDialog/index.js";
 
-export const PluginItem = ({name, version, author, description, enabled}) => {
+export const PluginItem = ({name, version, author, description, enabled, path}) => {
     const {plugins, updatePlugins} = useContext(PluginsContext);
 
-    const togglePlugin = (pluginName) => {
-        const plugin = plugins.find((p) => p.name === pluginName);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-        (!plugin?.enabled ? postRequest("plugin/", {name: pluginName}) : deleteRequest("plugin/", {name: pluginName}))
+    const togglePlugin = () => {
+        const plugin = plugins.find((p) => p.name === name);
+
+        (!plugin?.enabled ? postRequest("plugin/", {name: name}) : deleteRequest("plugin/", {name: name}))
+            .then(() => updatePlugins());
+
+        return true;
+    }
+
+    const deletePlugin = () => {
+        if (enabled) togglePlugin();
+
+        deleteRequest("filebrowser/file", {path: `plugins/${path}`})
             .then(() => updatePlugins());
 
         return true;
@@ -21,9 +34,18 @@ export const PluginItem = ({name, version, author, description, enabled}) => {
             <Typography variant="body2" color="text.secondary">by {author || "Unknown"}</Typography>
             <Typography variant="body1">{description || "No description provided"}</Typography>
 
-            <Stack direction="row" justifyContent="flex-end" sx={{mt: 1}}>
+            <ActionConfirmDialog title={`Delete ${name}`} description={`Are you sure you want to delete ${name}? You need to restart your server to apply the changes after deleting.`}
+                                 onClick={deletePlugin} successMessage="none"
+                                    open={deleteDialogOpen} setOpen={setDeleteDialogOpen} />
+
+            <Stack direction="row" justifyContent="flex-end" sx={{mt: 1, alignItems: "center"}} gap={1}>
+
+                {name !== "MinecraftDashboard" && <IconButton size="small" color="error" onClick={() => setDeleteDialogOpen(true)}>
+                    <Delete />
+                </IconButton>}
+
                 <Button variant="contained" size="small" color={enabled ? "error" : "success"} disabled={name === "MinecraftDashboard"}
-                        onClick={() => togglePlugin(name)}>{enabled ? "Disable" : "Enable"}</Button>
+                        onClick={togglePlugin}>{enabled ? "Disable" : "Enable"}</Button>
             </Stack>
         </Box>
     )

--- a/webui/src/states/Root/pages/Plugins/components/PluginItem/PluginItem.jsx
+++ b/webui/src/states/Root/pages/Plugins/components/PluginItem/PluginItem.jsx
@@ -1,4 +1,4 @@
-import {Box, Button, Chip, IconButton, Stack, Typography} from "@mui/material";
+import {Box, Button, Chip, IconButton, Stack, Tooltip, Typography} from "@mui/material";
 import React, {useContext, useState} from "react";
 import {deleteRequest, postRequest} from "@/common/utils/RequestUtil.js";
 import {PluginsContext} from "@/states/Root/pages/Plugins/contexts/Plugins";
@@ -40,9 +40,10 @@ export const PluginItem = ({name, version, author, description, enabled, path}) 
 
             <Stack direction="row" justifyContent="flex-end" sx={{mt: 1, alignItems: "center"}} gap={1}>
 
-                {name !== "MinecraftDashboard" && <IconButton size="small" color="error" onClick={() => setDeleteDialogOpen(true)}>
-                    <Delete />
-                </IconButton>}
+                {name !== "MinecraftDashboard" && <Tooltip title="Delete plugin">
+                    <IconButton size="small" color="error" onClick={() => setDeleteDialogOpen(true)}>
+                        <Delete/>
+                    </IconButton></Tooltip>}
 
                 <Button variant="contained" size="small" color={enabled ? "error" : "success"} disabled={name === "MinecraftDashboard"}
                         onClick={togglePlugin}>{enabled ? "Disable" : "Enable"}</Button>

--- a/webui/src/states/Root/pages/Plugins/components/PluginStore/PluginStore.jsx
+++ b/webui/src/states/Root/pages/Plugins/components/PluginStore/PluginStore.jsx
@@ -47,7 +47,7 @@ export const PluginStore = ({search, closeStore}) => {
             <Stack direction="row" sx={{my: 1, alignItems: "baseline"}} flexWrap="wrap">
                 {plugins.map((plugin) => <StoreItem {...plugin} key={plugin.id} closeStore={closeStore}
                                                     installed={currentPlugins.find((p) => p.path
-                                                        ?.includes("/Managed-" + plugin.id + ".jar"))} />)}
+                                                        ?.startsWith("Managed-" + plugin.id + ".jar"))} />)}
 
                 {plugins.length === 0 && <Typography sx={{width: "100%"}} textAlign="center">No plugins found</Typography>}
             </Stack>

--- a/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/StoreItem.jsx
+++ b/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/StoreItem.jsx
@@ -9,16 +9,16 @@ import {prettyDownloadCount} from "@/states/Root/pages/Plugins/components/Plugin
 export const StoreItem = ({id, name, description, icon, downloads, closeStore, installed}) => {
     const {updatePlugins} = useContext(PluginsContext);
     const [installing, setInstalling] = useState(false);
-    const [error, setError] = useState(false);
+    const [error, setError] = useState("");
     const [alreadyInstalled, setAlreadyInstalled] = useState(installed);
 
     const install = () => {
         setInstalling(true);
-        request("store/?id=" + id, "PUT", {}, {}, false).then((r) => {
+        request("store/?id=" + id, "PUT", {}, {}, false).then(async (r) => {
             setInstalling(false);
 
             if (r.status === 409) return setAlreadyInstalled(true);
-            if (!r.ok) return setError(true);
+            if (!r.ok) return setError((await r.json()).error || "Plugin not supported");
 
             updatePlugins();
             closeStore();
@@ -47,7 +47,7 @@ export const StoreItem = ({id, name, description, icon, downloads, closeStore, i
                 </Stack>
                 <Stack direction="row" alignItems="center" gap={1.5}>
                     {installing && <CircularProgress size={20} color="secondary" />}
-                    {error && <Tooltip title="Plugin not supported"><Warning color="error" /></Tooltip>}
+                    {error !== "" && <Tooltip title={error}><Warning color="error" /></Tooltip>}
 
                     {alreadyInstalled && <Tooltip title="Plugin already installed"><Error color="warning" /></Tooltip>}
 

--- a/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/StoreItem.jsx
+++ b/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/StoreItem.jsx
@@ -1,9 +1,10 @@
-import {Box, Button, CircularProgress, Stack, Tooltip, Typography} from "@mui/material";
+import {Box, Button, CircularProgress, Link, Stack, Tooltip, Typography} from "@mui/material";
 import React, {useContext, useState} from "react";
 import {Download, Error, Warning} from "@mui/icons-material";
 import {request} from "@/common/utils/RequestUtil.js";
 import {PluginsContext} from "@/states/Root/pages/Plugins/contexts/Plugins";
 import ResourceIcon from "@/common/assets/images/resource.webp";
+import {prettyDownloadCount} from "@/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/utils.js";
 
 export const StoreItem = ({id, name, description, icon, downloads, closeStore, installed}) => {
     const {updatePlugins} = useContext(PluginsContext);
@@ -28,8 +29,13 @@ export const StoreItem = ({id, name, description, icon, downloads, closeStore, i
         <Box backgroundColor="background.darker" borderRadius={2} padding={2} sx={{mr: 1, mt: 1, width: {xs: "100%", lg: 300}}}>
             <Box sx={{display: "flex", alignItems: "center", justifyContent: "space-between"}}>
                 <Typography variant="h6" fontWeight={500}>{name}</Typography>
-                <Box component="img" sx={{width: 40, height: 40, borderRadius: 50}}
-                     src={icon ? ("data:image/png;base64," + icon) : ResourceIcon} alt="icon"/>
+
+                <Tooltip title="View resource">
+                    <Link href={"https://www.spigotmc.org/resources/" + id} alt="icon" target="_blank">
+                        <Box component="img" sx={{width: 40, height: 40, borderRadius: 50}}
+                             src={icon ? ("data:image/png;base64," + icon) : ResourceIcon} rel="noreferrer"/>
+                    </Link>
+                </Tooltip>
             </Box>
 
             <Typography variant="body1">{description || "No description provided"}</Typography>
@@ -37,11 +43,12 @@ export const StoreItem = ({id, name, description, icon, downloads, closeStore, i
             <Stack direction="row" justifyContent="space-between" sx={{mt: 1}}>
                 <Stack direction="row" alignItems="center" gap={0.5}>
                     <Download color="secondary"/>
-                    <Typography variant="h6" fontWeight={500}>{downloads}</Typography>
+                    <Typography variant="h6" fontWeight={500}>{prettyDownloadCount(downloads)}</Typography>
                 </Stack>
                 <Stack direction="row" alignItems="center" gap={1.5}>
                     {installing && <CircularProgress size={20} color="secondary" />}
                     {error && <Tooltip title="Plugin not supported"><Warning color="error" /></Tooltip>}
+
                     {alreadyInstalled && <Tooltip title="Plugin already installed"><Error color="warning" /></Tooltip>}
 
                     <Button variant="contained" color="secondary" size="small" onClick={install}

--- a/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/utils.js
+++ b/webui/src/states/Root/pages/Plugins/components/PluginStore/components/StoreItem/utils.js
@@ -1,0 +1,5 @@
+export const prettyDownloadCount = (count) => {
+    if (count < 1000) return count;
+    if (count < 1000000) return (count / 1000).toFixed(1) + "K";
+    return (count / 1000000).toFixed(1) + "M";
+}


### PR DESCRIPTION
# 🧩 Updated the plugins page

I made some changes to the plugins page :)

## Changes

- [x] Bug-Fix: You can now search plugins which contain spaces in the store
- [x] Bug-Fix: There were CORS errors due to spigots image api ( images are now loaded through base64)
- [x] Downloads now show minified (1000 -> 1K, 1400000 -> 1.4M)
- [x] You are now able to view the resource by clicking the icon
- [x] You can now delete plugins directly from the server (requires restart)
- [x] The plugins page now shows the count of plugins at the top
- [x] Plugins are now sorted by downloads, not "old -> new"
- [x] The error tooltips now show a detailed error if a plugin installation failed

## Screenshots

### "View resource" on icon click
![Screenshot_20230702_225529](https://github.com/gnmyt/MCDash/assets/35641351/48e92031-fb91-441c-9703-d7ab37ed2acb)

### Error
![Screenshot_20230702_225643](https://github.com/gnmyt/MCDash/assets/35641351/d1dfaafe-3d88-4f90-8eee-ee2e07f2a6b2)

### Delete plugin
![Screenshot_20230702_230037](https://github.com/gnmyt/MCDash/assets/35641351/2830c4ad-6a11-4e93-a374-a61f8de62156)
