### PR TITLE
🐛 Fixed the limit in the console route

### DIFF
--- a/src/main/java/de/gnmyt/mcdash/panel/routes/ConsoleRoute.java
+++ b/src/main/java/de/gnmyt/mcdash/panel/routes/ConsoleRoute.java
@@ -49,7 +49,7 @@ public class ConsoleRoute extends DefaultHandler {
 
         StringBuilder log = new StringBuilder();
         for (int i = startLine - 1; i < lines.length; i++) {
-            if (i >= limit) break;
+            if (i >= startLine + limit - 1) break;
             if (i != startLine - 1) log.append("\n");
             log.append(lines[i]);
         }


### PR DESCRIPTION
# 🐛 Fixed the limit in the console route
The new update (1.1.5) introduced a new bug that limited the console output lines to 500 (`line >= limit`). It has now been updated to match the startLine (`line >= startLine + limit - 1`)