### PR TITLE
🐛 Fixed text selection inside file editor

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -17,7 +17,7 @@
     "@mui/material": "^5.13.5",
     "@mui/x-charts": "^6.0.0-alpha.7",
     "@mui/x-data-grid": "^6.8.0",
-    "@uiw/codemirror-theme-atomone": "^4.21.3",
+    "@uiw/codemirror-theme-dracula": "^4.21.13",
     "@uiw/react-codemirror": "^4.21.3",
     "buffer": "^6.0.3",
     "i18next": "^23.4.4",

--- a/webui/src/states/Root/pages/Files/components/FileEditor/FileEditor.jsx
+++ b/webui/src/states/Root/pages/Files/components/FileEditor/FileEditor.jsx
@@ -1,12 +1,14 @@
 import CodeMirror from "@uiw/react-codemirror";
 import {dracula} from "@uiw/codemirror-theme-dracula";
 import {Box, Fab} from "@mui/material";
-import {useEffect, useState} from "react";
+import {useContext, useEffect, useState} from "react";
 import {patchRequest, request} from "@/common/utils/RequestUtil.js";
 import {Save} from "@mui/icons-material";
 import {t} from "i18next";
+import {SettingsContext} from "@contexts/Settings";
 
 export const FileEditor = ({directory, currentFile, setSnackbar}) => {
+    const {theme} = useContext(SettingsContext);
 
     const [fileContent, setFileContent] = useState("");
     const [fileContentChanged, setFileContentChanged] = useState(false);
@@ -40,7 +42,7 @@ export const FileEditor = ({directory, currentFile, setSnackbar}) => {
                                         onClick={saveFile}><Save/></Fab>}
             <Box sx={{borderRadius: 2, overflow: "hidden"}}>
                 <CodeMirror value={fileContent === null ? t("files.loading") : fileContent} onChange={updateContent}
-                            theme={dracula}/>
+                            theme={theme === "dark" ? dracula : "light"}/>
             </Box>
         </Box>
     )

--- a/webui/src/states/Root/pages/Files/components/FileEditor/FileEditor.jsx
+++ b/webui/src/states/Root/pages/Files/components/FileEditor/FileEditor.jsx
@@ -1,5 +1,5 @@
 import CodeMirror from "@uiw/react-codemirror";
-import {atomone} from "@uiw/codemirror-theme-atomone";
+import {dracula} from "@uiw/codemirror-theme-dracula";
 import {Box, Fab} from "@mui/material";
 import {useEffect, useState} from "react";
 import {patchRequest, request} from "@/common/utils/RequestUtil.js";
@@ -38,7 +38,10 @@ export const FileEditor = ({directory, currentFile, setSnackbar}) => {
         <Box display="flex" flexDirection="column" gap={1} marginTop={2} sx={{maxWidth: "85vw"}}>
             {fileContentChanged && <Fab color="secondary" sx={{position: "fixed", bottom: 20, right: 20}}
                                         onClick={saveFile}><Save/></Fab>}
-            <CodeMirror value={fileContent === null ? t("files.loading") : fileContent} onChange={updateContent} theme={atomone}/>
+            <Box sx={{borderRadius: 2, overflow: "hidden"}}>
+                <CodeMirror value={fileContent === null ? t("files.loading") : fileContent} onChange={updateContent}
+                            theme={dracula}/>
+            </Box>
         </Box>
     )
 }

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -839,6 +839,22 @@
   dependencies:
     "@uiw/codemirror-themes" "4.21.3"
 
+"@uiw/codemirror-theme-dracula@^4.21.13":
+  version "4.21.13"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.13.tgz#63dd60922f977190c73bd530b3152216b37c6ec8"
+  integrity sha512-NpgILuYuFayxx8zXTv0Uf57wyNzdxeGg/Ru3UIGBngicBtmRtFn9c3PmDU9lYxL8OseMzWJvrjaELEIiOrFqyQ==
+  dependencies:
+    "@uiw/codemirror-themes" "4.21.13"
+
+"@uiw/codemirror-themes@4.21.13":
+  version "4.21.13"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-themes/-/codemirror-themes-4.21.13.tgz#153cc00b8675963cc796d57b2e38bd902aef8fd3"
+  integrity sha512-+IeYow6kmz1LJmXd1rL7ngVxb5lm2wKrjYNfomDvmoUz2gKcca8y7pWGMIFhIsabrNW11SFVSloVkj9ZXw7e1Q==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 "@uiw/codemirror-themes@4.21.3":
   version "4.21.3"
   resolved "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.3.tgz"


### PR DESCRIPTION
# 🐛 Fixed text selection inside file editor
1. For some reason, the "atom one" theme I was using for the file editor was causing the unintended side effect of the text selection not working. I changed the theme to "Dracula" and now it works. This fixes #52.
2. The light theme now also shows the light text editor instead of the dark one.

## Screenshots
![Screenshot_20230908_100158](https://github.com/gnmyt/MCDash/assets/35641351/aefb22b9-bad1-4488-8a93-25c13b09dc9a)

![Screenshot_20230908_100248](https://github.com/gnmyt/MCDash/assets/35641351/fc98a17c-d6c5-4ba4-abf5-9e76258492b1)