### PR TITLE
🐛 Fixed the whitelist table bug

### DIFF
--- a/webui/src/states/Root/pages/Players/components/WhiteListTable/columns.jsx
+++ b/webui/src/states/Root/pages/Players/components/WhiteListTable/columns.jsx
@@ -16,7 +16,7 @@ const columns = () => [
     {field: 'uuid', headerName: t("players.id"), flex: 1, minWidth: 200},
     {
         field: 'last_seen', headerName: t("players.last_seen"), flex: 1, minWidth: 100, renderCell: (params) =>
-            (<Typography>{new Date(params.row.last_seen).toLocaleString()}</Typography>)
+            (<Typography>{new Date(params.row.last_seen).getDate() === 1 ? "-" : new Date(params.row.last_seen).toLocaleString()}</Typography>)
     }
 ];
 


### PR DESCRIPTION
# 🐛 Fixed the whitelist table bug
The whitelist table used to show the date even if the Unix time was `1` (January 1, 1970 - start of Unix time). Now it shows a "-" instead if the player has never been online. This fixes #74 