### PR TITLE
🐛 Fixed the table localization bug

### DIFF
--- a/webui/public/assets/locales/en.json
+++ b/webui/public/assets/locales/en.json
@@ -248,6 +248,11 @@
       "kicked": "You have been kicked!",
       "kick": "Kick",
       "ban": "Ban"
+    },
+    "none": {
+      "online": "No players online",
+      "whitelisted": "No whitelisted players found",
+      "banned": "No banned players found"
     }
   },
   "schedules": {

--- a/webui/public/assets/locales/en.json
+++ b/webui/public/assets/locales/en.json
@@ -253,7 +253,8 @@
       "online": "No players online",
       "whitelisted": "No whitelisted players found",
       "banned": "No banned players found"
-    }
+    },
+    "per_page": "Players per page"
   },
   "schedules": {
     "create": "Create schedule",

--- a/webui/src/states/Root/pages/Players/components/BanListTable/BanListTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/BanListTable/BanListTable.jsx
@@ -2,6 +2,8 @@ import {useContext} from "react";
 import {BanListContext} from "@/states/Root/pages/Players/contexts/BanList";
 import {DataGrid} from "@mui/x-data-grid";
 import columns from "./columns.jsx";
+import {Stack} from "@mui/material";
+import {t} from "i18next";
 
 export const BanListTable = ({setSelectedBannedPlayers}) => {
     const {bannedPlayers} = useContext(BanListContext);
@@ -21,6 +23,11 @@ export const BanListTable = ({setSelectedBannedPlayers}) => {
                 }}
                 sx={{display: 'grid', gridTemplateRows: 'auto 1f auto'}}
                 autoHeight={true}
+                slots={{
+                    noRowsOverlay: () => <Stack sx={{height: "100%", alignItems: "center", justifyContent: "center"}}>
+                        {t("players.none.banned")}
+                    </Stack>
+                }}
             />
         </>
     );

--- a/webui/src/states/Root/pages/Players/components/BanListTable/BanListTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/BanListTable/BanListTable.jsx
@@ -28,6 +28,7 @@ export const BanListTable = ({setSelectedBannedPlayers}) => {
                         {t("players.none.banned")}
                     </Stack>
                 }}
+                slotProps={{pagination: {labelRowsPerPage: t("players.per_page")}}}
             />
         </>
     );

--- a/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
@@ -4,7 +4,7 @@ import {useContext, useState} from "react";
 import {PlayerContext} from "@contexts/Players";
 import {deleteRequest, putRequest} from "@/common/utils/RequestUtil.js";
 import ActionConfirmDialog from "@components/ActionConfirmDialog";
-import {Alert, Snackbar} from "@mui/material";
+import {Alert, Snackbar, Stack} from "@mui/material";
 import PlayerTeleportDialog
     from "@/states/Root/pages/Players/components/PlayerTable/components/PlayerTeleportDialog";
 import {t} from "i18next";
@@ -72,6 +72,11 @@ export const PlayerTable = ({setSelectedPlayers}) => {
                 onRowSelectionModelChange={(newSelection) => {setSelectedPlayers(newSelection)}}
                 sx={{display: 'grid', gridTemplateRows: 'auto 1f auto'}}
                 autoHeight={true}
+                slots={{
+                    noRowsOverlay: () => <Stack sx={height: "100%", alignItems: "center", justifyContent: "center"}}>
+                        {t("players.none.online")}
+                    </Stack>
+                }}
             />
         </>
     );

--- a/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
@@ -77,6 +77,7 @@ export const PlayerTable = ({setSelectedPlayers}) => {
                         {t("players.none.online")}
                     </Stack>
                 }}
+                slotProps={{pagination: {labelRowsPerPage: t("players.per_page")}}}
             />
         </>
     );

--- a/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/PlayerTable/PlayerTable.jsx
@@ -73,7 +73,7 @@ export const PlayerTable = ({setSelectedPlayers}) => {
                 sx={{display: 'grid', gridTemplateRows: 'auto 1f auto'}}
                 autoHeight={true}
                 slots={{
-                    noRowsOverlay: () => <Stack sx={height: "100%", alignItems: "center", justifyContent: "center"}}>
+                    noRowsOverlay: () => <Stack sx={{height: "100%", alignItems: "center", justifyContent: "center"}}>
                         {t("players.none.online")}
                     </Stack>
                 }}

--- a/webui/src/states/Root/pages/Players/components/WhiteListTable/WhiteListTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/WhiteListTable/WhiteListTable.jsx
@@ -28,6 +28,7 @@ export const WhiteListTable = ({setSelectedWhitelistedPlayers}) => {
                         {t("players.none.whitelisted")}
                     </Stack>
                 }}
+                slotProps={{pagination: {labelRowsPerPage: t("players.per_page")}}}
             />
         </>
     );

--- a/webui/src/states/Root/pages/Players/components/WhiteListTable/WhiteListTable.jsx
+++ b/webui/src/states/Root/pages/Players/components/WhiteListTable/WhiteListTable.jsx
@@ -2,6 +2,8 @@ import {useContext} from "react";
 import {WhiteListContext} from "@/states/Root/pages/Players/contexts/WhiteList";
 import {DataGrid} from "@mui/x-data-grid";
 import columns from "./columns.jsx";
+import {Stack} from "@mui/material";
+import {t} from "i18next";
 
 export const WhiteListTable = ({setSelectedWhitelistedPlayers}) => {
     const {whitelistedPlayers} = useContext(WhiteListContext);
@@ -21,6 +23,11 @@ export const WhiteListTable = ({setSelectedWhitelistedPlayers}) => {
                 }}
                 sx={{display: 'grid', gridTemplateRows: 'auto 1f auto'}}
                 autoHeight={true}
+                slots={{
+                    noRowsOverlay: () => <Stack sx={{height: "100%", alignItems: "center", justifyContent: "center"}}>
+                        {t("players.none.whitelisted")}
+                    </Stack>
+                }}
             />
         </>
     );


### PR DESCRIPTION
# 🐛 Fixed the table localization bug
There was a problem with the tables displaying "No rows" instead of the localized translation. The new translation strings `players.none.online`, `players.none.whitelisted` and `players.none.banned` fix this issue and also improve readability on the site. This fixes #78 

## Screenshots
![Screenshot_20231028_101112](https://github.com/gnmyt/MCDash/assets/35641351/3068c2ac-9cbe-4cfa-9128-d20926cc0cec)
