### PR TITLE
Changed the process of downloading backups.

### DIFF
--- a/modules/api/src/main/java/de/gnm/voxeldash/api/routes/BackupRouter.java
+++ b/modules/api/src/main/java/de/gnm/voxeldash/api/routes/BackupRouter.java
@@ -83,13 +83,13 @@ public class BackupRouter extends BaseRoute {
         return new JSONResponse().add("backups", backups);
     }
 
-    @ApiDoc(summary = "Download a backup", description = "Streams the requested backup archive as a downloadable file.", tag = "Backups")
-    @ApiField(name = "backupName", in = ParamLocation.PATH, description = "Name/ID of the backup to download")
+    @ApiDoc(summary = "Generate a temporary download link for a backup", description = "Returns 60s, single-use URL that can be used to download a backup without auth headers.", tag = "Backups")
+    @ApiField(name = "backupName", in = ParamLocation.PATH, description = "ID of the backup to download")
     @AuthenticatedRoute
     @RequiresFeatures(Feature.Backups)
-    @Path("/backups/download/:backupName")
+    @Path("/backups/download/:backupName/link")
     @Method(GET)
-    public Response downloadFile(RawRequest request) {
+    public Response createDownloadLink(RawRequest request) {
         String backupName = request.getParameter("backupName");
 
         if (!backupHelper.backupExists(backupName)) return new JSONResponse().error("Backup not found");
@@ -97,15 +97,35 @@ public class BackupRouter extends BaseRoute {
         File backupFile = backupHelper.getBackup(backupName);
         if (backupFile == null) return new JSONResponse().error("Backup not found");
 
+        String[] nameParts = backupFile.getName().replace(".zip", "").split("-");
+        String decodedName = nameParts.length > 2 ? BackupHelper.decodeName(nameParts[2]) : "";
+        String downloadName = (decodedName.isEmpty() ? backupName : decodedName) + ".zip";
+
+        String token = UUID.randomUUID().toString();
+        pendingDownloads.put(token, new PendingDownload(backupFile, downloadName, System.currentTimeMillis() + TOKEN_TTL_MS));
+
+        return new JSONResponse().add("url", "/api/backups/download/token/" + token);
+    }
+
+    @ApiDoc(summary = "Download a backup via temporary token", description = "Streams the backup archive using a single-use token minted by the link endpoint. No auth headers required.", tag = "Backups")
+    @ApiField(name = "token", in = ParamLocation.PATH, description = "Single-use token from the download-link endpoint")
+    @Path("/backups/download/token/:token")
+    @Method(GET)
+    public Response downloadFile(RawRequest request) {
+        String token = request.getParameter("token");
+        if (token == null) return new JSONResponse().error("Missing token");
+
+        PendingDownload pending = pendingDownloads.remove(token); 
+        if (pending == null) return new JSONResponse().error("Invalid or expired token");
+        if (System.currentTimeMillis() > pending.expiresAt()) return new JSONResponse().error("Token expired");
+        if (!pending.file().exists()) return new JSONResponse().error("Backup not found");
+
         try {
-            BufferedInputStream in = new BufferedInputStream(Files.newInputStream(backupFile.toPath()));
-            String[] nameParts = backupFile.getName().replace(".zip", "").split("-");
-            String decodedName = nameParts.length > 2 ? BackupHelper.decodeName(nameParts[2]) : "";
-            String downloadName = (decodedName.isEmpty() ? backupName : decodedName) + ".zip";
+            BufferedInputStream in = new BufferedInputStream(Files.newInputStream(pending.file().toPath()));
             return new Response()
                     .header("Content-Type", "application/octet-stream")
-                    .header("Content-Disposition", "attachment; filename=\"" + downloadName + "\"")
-                    .header("Content-Length", String.valueOf(backupFile.length()))
+                    .header("Content-Disposition", "attachment; filename=\"" + pending.downloadName() + "\"")
+                    .header("Content-Length", String.valueOf(pending.file().length()))
                     .stream(in);
         } catch (Exception e) {
             return new JSONResponse().error("Error downloading file: " + e.getMessage());

--- a/modules/api/src/main/java/de/gnm/voxeldash/api/routes/BackupRouter.java
+++ b/modules/api/src/main/java/de/gnm/voxeldash/api/routes/BackupRouter.java
@@ -23,6 +23,10 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.nio.file.Files;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static de.gnm.voxeldash.api.http.HTTPMethod.*;
 
 public class BackupRouter extends BaseRoute {
@@ -81,6 +85,25 @@ public class BackupRouter extends BaseRoute {
         }
 
         return new JSONResponse().add("backups", backups);
+    }
+
+    private static final Map<String, PendingDownload> pendingDownloads = new ConcurrentHashMap<>();
+    private static final long TOKEN_TTL_MS = 60_000; // 60s to actually start the download
+
+    private static final class PendingDownload {
+        private final File file;
+        private final String downloadName;
+        private final long expiresAt;
+
+        private PendingDownload(File file, String downloadName, long expiresAt) {
+            this.file = file;
+            this.downloadName = downloadName;
+            this.expiresAt = expiresAt;
+        }
+
+        File file() { return file; }
+        String downloadName() { return downloadName; }
+        long expiresAt() { return expiresAt; }
     }
 
     @ApiDoc(summary = "Generate a temporary download link for a backup", description = "Returns 60s, single-use URL that can be used to download a backup without auth headers.", tag = "Backups")

--- a/ui/src/lib/RequestUtil.ts
+++ b/ui/src/lib/RequestUtil.ts
@@ -70,17 +70,17 @@ export const patchRequest = async (path: string, body = {}, headers = {}) => {
 }
 
 export const downloadRequest = async (path: string, body = {}, headers = {}) => {
-    const file = await request(path, "GET", body, headers);
-    const element = document.createElement('a');
-    const url = file.headers.get('Content-Disposition')?.split('filename=')[1] || "file";
-    element.setAttribute("download", url.replaceAll("\"", ""));
+    const linkResp = await request(`${path}/link`, "GET", body, headers, false);
+    if (!linkResp.ok) throw new Error(`Failed to get download link: ${linkResp.status}`);
+    const { url } = await linkResp.json();
 
-    const blob = await file.blob();
-    element.href = window.URL.createObjectURL(blob);
-    document.body.appendChild(element);
-    element.click();
-    element.remove();
-}
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = '';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+};
 
 export const masterRequest = async (path: string, method = "GET", body?: unknown) => {
     return await fetch("/master/" + path, {


### PR DESCRIPTION
#234 

Applies changes outlined in this issue. Tested only on spigot.

Instead of downloading a blob then saving it after completely downloaded, now it GET's a temporary link that gets opened to download a backup directly, allowing for the usage of the browsers built-in download manager, giving ability to cancel, pause, open on completion, etc.